### PR TITLE
Feat: migrate to mongodb 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"eslint-config-airbnb-base": "13.1.0",
 				"eslint-plugin-import": "2.17.2",
 				"mocha": "6.1.4",
-				"mongodb": "^4.14.0",
+				"mongodb": "^5.9.0",
 				"nyc": "14.1.1",
 				"prettier": "1.17.0",
 				"should": "13.2.3",
@@ -41,7 +41,7 @@
 				"node": ">=8"
 			},
 			"peerDependencies": {
-				"mongodb": "3.6.3 || ^4"
+				"mongodb": "^4.14.0 || ^5.9.0"
 			}
 		},
 		"node_modules/@aws-crypto/ie11-detection": {
@@ -50,6 +50,7 @@
 			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^1.11.1"
 			}
@@ -59,7 +60,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-crypto/sha256-browser": {
 			"version": "3.0.0",
@@ -67,6 +69,7 @@
 			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-crypto/ie11-detection": "^3.0.0",
 				"@aws-crypto/sha256-js": "^3.0.0",
@@ -83,7 +86,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-crypto/sha256-js": {
 			"version": "3.0.0",
@@ -91,6 +95,7 @@
 			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-crypto/util": "^3.0.0",
 				"@aws-sdk/types": "^3.222.0",
@@ -102,7 +107,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-crypto/supports-web-crypto": {
 			"version": "3.0.0",
@@ -110,6 +116,7 @@
 			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^1.11.1"
 			}
@@ -119,7 +126,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-crypto/util": {
 			"version": "3.0.0",
@@ -127,6 +135,7 @@
 			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -138,7 +147,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@aws-sdk/abort-controller": {
 			"version": "3.272.0",
@@ -146,6 +156,7 @@
 			"integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -160,6 +171,7 @@
 			"integrity": "sha512-FJ15FTYNSqCNDxqnr7la7s4CldVBxGHeBCk4uPm9M9RKZY2tsR0fbdT2a7xTQnRYpi+bMWHhnXF5U2aH0CivqA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
@@ -207,6 +219,7 @@
 			"integrity": "sha512-3RvO5zClQhu37w9VMLoHPGk58S3y8Spb7XX8rW51bm5TUglYQskQ0X2VLEUW/7ZGx/peokHws9Z9+w5yGq5sdA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
@@ -251,6 +264,7 @@
 			"integrity": "sha512-P6zf9pDuxApVoCYStAg7L8BU9AcWI8PxfLSX4r2WnmcQropxzPJ3op1j9nvbwwBDMFWephijVY4AVp8MqPcPyg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
@@ -295,6 +309,7 @@
 			"integrity": "sha512-w8QomyhCVEArRcXgOkjbofiS/PLEKWRAyYBovjMS1cGhns2ZYJXFgHNgr3VGE54TghUc5dR1CqKuBKKM4ThrgA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
@@ -343,6 +358,7 @@
 			"integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/signature-v4": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -360,6 +376,7 @@
 			"integrity": "sha512-N4DxVR1FM+IhodiAb2pnZ0OwszEZP9mfMVg27BZMXVwIISOcb/wPgv7Sp7tR90fu5Nq7yIle8ThvY0HW5wH+SA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/client-cognito-identity": "3.281.0",
 				"@aws-sdk/property-provider": "3.272.0",
@@ -376,6 +393,7 @@
 			"integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/property-provider": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -391,6 +409,7 @@
 			"integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/node-config-provider": "3.272.0",
 				"@aws-sdk/property-provider": "3.272.0",
@@ -408,6 +427,7 @@
 			"integrity": "sha512-H99nhMhHImQKgNhHKYc6usTS6UK8KzCcVGpILLVTuP97YlrYAMFAVstA3Xk6mZ28JAbHVXvI6vJjkMNOzCSKCA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "3.272.0",
 				"@aws-sdk/credential-provider-imds": "3.272.0",
@@ -429,6 +449,7 @@
 			"integrity": "sha512-jhddd+lJp8G8hBJ+6glmXjfWJT3nxiE1aliH3fBC4RR3D+1kRXc99Xg6mbUb8bm+GrVZ4gzfiqSgg+ByKjd7xA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "3.272.0",
 				"@aws-sdk/credential-provider-imds": "3.272.0",
@@ -451,6 +472,7 @@
 			"integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/property-provider": "3.272.0",
 				"@aws-sdk/shared-ini-file-loader": "3.272.0",
@@ -467,6 +489,7 @@
 			"integrity": "sha512-IqJnpXuLpJYoSCf/Rt66/CPVTjfkam3z9+ZvlQJV+VbK+vGj276qEtTmSN3XPZZgF1XbWptvkzIWDszLhHiZmg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/client-sso": "3.281.0",
 				"@aws-sdk/property-provider": "3.272.0",
@@ -485,6 +508,7 @@
 			"integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/property-provider": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -500,6 +524,7 @@
 			"integrity": "sha512-xp0e49jlSHCH/jt+G89PF1L2MbiGnSSwCxehyEBcIzX5xfdPWY8baAgRIT6wGYyNy5mnx1Z32SyfwcG3ns4n9A==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/client-cognito-identity": "3.281.0",
 				"@aws-sdk/client-sso": "3.281.0",
@@ -527,6 +552,7 @@
 			"integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/protocol-http": "3.272.0",
 				"@aws-sdk/querystring-builder": "3.272.0",
@@ -541,6 +567,7 @@
 			"integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.272.0",
 				"@aws-sdk/util-buffer-from": "3.208.0",
@@ -557,6 +584,7 @@
 			"integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -568,6 +596,7 @@
 			"integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -581,6 +610,7 @@
 			"integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/protocol-http": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -596,6 +626,7 @@
 			"integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/middleware-serde": "3.272.0",
 				"@aws-sdk/protocol-http": "3.272.0",
@@ -616,6 +647,7 @@
 			"integrity": "sha512-oTkF3exy89KE8NgSeXFwD+0H0GRKL2qUw92t3caEj7+4KzU/0m3t7NtKlq2NLRtTJhZ/izYRpV536oogLzGm3g==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/protocol-http": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -631,6 +663,7 @@
 			"integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -645,6 +678,7 @@
 			"integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/protocol-http": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -660,6 +694,7 @@
 			"integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/protocol-http": "3.272.0",
 				"@aws-sdk/service-error-classification": "3.272.0",
@@ -679,6 +714,7 @@
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
@@ -689,6 +725,7 @@
 			"integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/middleware-signing": "3.272.0",
 				"@aws-sdk/property-provider": "3.272.0",
@@ -707,6 +744,7 @@
 			"integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -721,6 +759,7 @@
 			"integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/property-provider": "3.272.0",
 				"@aws-sdk/protocol-http": "3.272.0",
@@ -739,6 +778,7 @@
 			"integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -752,6 +792,7 @@
 			"integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/protocol-http": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -767,6 +808,7 @@
 			"integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/property-provider": "3.272.0",
 				"@aws-sdk/shared-ini-file-loader": "3.272.0",
@@ -783,6 +825,7 @@
 			"integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/abort-controller": "3.272.0",
 				"@aws-sdk/protocol-http": "3.272.0",
@@ -800,6 +843,7 @@
 			"integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -814,6 +858,7 @@
 			"integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -828,6 +873,7 @@
 			"integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.272.0",
 				"@aws-sdk/util-uri-escape": "3.201.0",
@@ -843,6 +889,7 @@
 			"integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -857,6 +904,7 @@
 			"integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -867,6 +915,7 @@
 			"integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -881,6 +930,7 @@
 			"integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/is-array-buffer": "3.201.0",
 				"@aws-sdk/types": "3.272.0",
@@ -900,6 +950,7 @@
 			"integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/middleware-stack": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -915,6 +966,7 @@
 			"integrity": "sha512-36Vg/F6Edm7qdjcTeNVON+sK2edgHhmhTtAEjWcuUk5AX/Et+Ate/A2N8HD3nxwlAcgidfnBC9SHYJatbhcEnQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/client-sso-oidc": "3.281.0",
 				"@aws-sdk/property-provider": "3.272.0",
@@ -932,6 +984,7 @@
 			"integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -945,6 +998,7 @@
 			"integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/querystring-parser": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -957,6 +1011,7 @@
 			"integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/util-buffer-from": "3.208.0",
 				"tslib": "^2.3.1"
@@ -971,6 +1026,7 @@
 			"integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			}
@@ -981,6 +1037,7 @@
 			"integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -994,6 +1051,7 @@
 			"integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/is-array-buffer": "3.201.0",
 				"tslib": "^2.3.1"
@@ -1008,6 +1066,7 @@
 			"integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -1021,6 +1080,7 @@
 			"integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/property-provider": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -1037,6 +1097,7 @@
 			"integrity": "sha512-A2NB10xReWC+GSnOivKGZ9rnljIZdEP8WMCQQEnA6DJNI19AUFF/O9QJ9y+cHGLKEms7jH86Y99wShdpzAK+Jw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/config-resolver": "3.272.0",
 				"@aws-sdk/credential-provider-imds": "3.272.0",
@@ -1055,6 +1116,7 @@
 			"integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -1069,6 +1131,7 @@
 			"integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -1082,6 +1145,7 @@
 			"integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -1095,6 +1159,7 @@
 			"integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -1108,6 +1173,7 @@
 			"integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/service-error-classification": "3.272.0",
 				"tslib": "^2.3.1"
@@ -1122,6 +1188,7 @@
 			"integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -1135,6 +1202,7 @@
 			"integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.272.0",
 				"bowser": "^2.11.0",
@@ -1147,6 +1215,7 @@
 			"integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/node-config-provider": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -1170,6 +1239,7 @@
 			"integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/util-buffer-from": "3.208.0",
 				"tslib": "^2.3.1"
@@ -1184,6 +1254,7 @@
 			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			}
@@ -1464,6 +1535,16 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
+			}
+		},
+		"node_modules/@mongodb-js/saslprep": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+			"integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"sparse-bitfield": "^3.0.3"
 			}
 		},
 		"node_modules/@sinonjs/commons": {
@@ -1806,26 +1887,6 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/bluebird": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
@@ -1836,7 +1897,8 @@
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
 			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -1855,39 +1917,12 @@
 			"dev": true
 		},
 		"node_modules/bson": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
-			"integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-5.5.0.tgz",
+			"integrity": "sha512-B+QB4YmDx9RStKv8LLSl/aVIEV3nYJc3cJNNTK2Cd1TL+7P+cNpw9mAPeCgc5K+j01Dv6sxUzcITXDx7ZU3F0w==",
 			"dev": true,
-			"dependencies": {
-				"buffer": "^5.6.0"
-			},
 			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
+				"node": ">=14.20.1"
 			}
 		},
 		"node_modules/buffer-from": {
@@ -2699,6 +2734,7 @@
 			"integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"strnum": "^1.0.5"
 			},
@@ -3130,26 +3166,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
 		},
 		"node_modules/ignore": {
 			"version": "3.3.10",
@@ -4014,21 +4030,44 @@
 			}
 		},
 		"node_modules/mongodb": {
-			"version": "4.14.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.14.0.tgz",
-			"integrity": "sha512-coGKkWXIBczZPr284tYKFLg+KbGPPLlSbdgfKAb6QqCFt5bo5VFZ50O3FFzsw4rnkqjwT6D8Qcoo9nshYKM7Mg==",
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.0.tgz",
+			"integrity": "sha512-g+GCMHN1CoRUA+wb1Agv0TI4YTSiWr42B5ulkiAfLLHitGK1R+PkSAf3Lr5rPZwi/3F04LiaZEW0Kxro9Fi2TA==",
 			"dev": true,
 			"dependencies": {
-				"bson": "^4.7.0",
-				"mongodb-connection-string-url": "^2.5.4",
+				"bson": "^5.5.0",
+				"mongodb-connection-string-url": "^2.6.0",
 				"socks": "^2.7.1"
 			},
 			"engines": {
-				"node": ">=12.9.0"
+				"node": ">=14.20.1"
 			},
 			"optionalDependencies": {
-				"@aws-sdk/credential-providers": "^3.186.0",
-				"saslprep": "^1.0.3"
+				"@mongodb-js/saslprep": "^1.1.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-providers": "^3.188.0",
+				"@mongodb-js/zstd": "^1.0.0",
+				"kerberos": "^1.0.0 || ^2.0.0",
+				"mongodb-client-encryption": ">=2.3.0 <3",
+				"snappy": "^7.2.2"
+			},
+			"peerDependenciesMeta": {
+				"@aws-sdk/credential-providers": {
+					"optional": true
+				},
+				"@mongodb-js/zstd": {
+					"optional": true
+				},
+				"kerberos": {
+					"optional": true
+				},
+				"mongodb-client-encryption": {
+					"optional": true
+				},
+				"snappy": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/mongodb-connection-string-url": {
@@ -4879,19 +4918,6 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
-		"node_modules/saslprep": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"sparse-bitfield": "^3.0.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -5234,7 +5260,8 @@
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
 			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "5.5.0",
@@ -6066,6 +6093,7 @@
 			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^1.11.1"
 			},
@@ -6075,7 +6103,8 @@
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				}
 			}
 		},
@@ -6085,6 +6114,7 @@
 			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-crypto/ie11-detection": "^3.0.0",
 				"@aws-crypto/sha256-js": "^3.0.0",
@@ -6101,7 +6131,8 @@
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				}
 			}
 		},
@@ -6111,6 +6142,7 @@
 			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-crypto/util": "^3.0.0",
 				"@aws-sdk/types": "^3.222.0",
@@ -6122,7 +6154,8 @@
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				}
 			}
 		},
@@ -6132,6 +6165,7 @@
 			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^1.11.1"
 			},
@@ -6141,7 +6175,8 @@
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				}
 			}
 		},
@@ -6151,6 +6186,7 @@
 			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -6162,7 +6198,8 @@
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				}
 			}
 		},
@@ -6172,6 +6209,7 @@
 			"integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -6183,6 +6221,7 @@
 			"integrity": "sha512-FJ15FTYNSqCNDxqnr7la7s4CldVBxGHeBCk4uPm9M9RKZY2tsR0fbdT2a7xTQnRYpi+bMWHhnXF5U2aH0CivqA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
@@ -6227,6 +6266,7 @@
 			"integrity": "sha512-3RvO5zClQhu37w9VMLoHPGk58S3y8Spb7XX8rW51bm5TUglYQskQ0X2VLEUW/7ZGx/peokHws9Z9+w5yGq5sdA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
@@ -6268,6 +6308,7 @@
 			"integrity": "sha512-P6zf9pDuxApVoCYStAg7L8BU9AcWI8PxfLSX4r2WnmcQropxzPJ3op1j9nvbwwBDMFWephijVY4AVp8MqPcPyg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
@@ -6309,6 +6350,7 @@
 			"integrity": "sha512-w8QomyhCVEArRcXgOkjbofiS/PLEKWRAyYBovjMS1cGhns2ZYJXFgHNgr3VGE54TghUc5dR1CqKuBKKM4ThrgA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
@@ -6354,6 +6396,7 @@
 			"integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/signature-v4": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -6368,6 +6411,7 @@
 			"integrity": "sha512-N4DxVR1FM+IhodiAb2pnZ0OwszEZP9mfMVg27BZMXVwIISOcb/wPgv7Sp7tR90fu5Nq7yIle8ThvY0HW5wH+SA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/client-cognito-identity": "3.281.0",
 				"@aws-sdk/property-provider": "3.272.0",
@@ -6381,6 +6425,7 @@
 			"integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/property-provider": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -6393,6 +6438,7 @@
 			"integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/node-config-provider": "3.272.0",
 				"@aws-sdk/property-provider": "3.272.0",
@@ -6407,6 +6453,7 @@
 			"integrity": "sha512-H99nhMhHImQKgNhHKYc6usTS6UK8KzCcVGpILLVTuP97YlrYAMFAVstA3Xk6mZ28JAbHVXvI6vJjkMNOzCSKCA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/credential-provider-env": "3.272.0",
 				"@aws-sdk/credential-provider-imds": "3.272.0",
@@ -6425,6 +6472,7 @@
 			"integrity": "sha512-jhddd+lJp8G8hBJ+6glmXjfWJT3nxiE1aliH3fBC4RR3D+1kRXc99Xg6mbUb8bm+GrVZ4gzfiqSgg+ByKjd7xA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/credential-provider-env": "3.272.0",
 				"@aws-sdk/credential-provider-imds": "3.272.0",
@@ -6444,6 +6492,7 @@
 			"integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/property-provider": "3.272.0",
 				"@aws-sdk/shared-ini-file-loader": "3.272.0",
@@ -6457,6 +6506,7 @@
 			"integrity": "sha512-IqJnpXuLpJYoSCf/Rt66/CPVTjfkam3z9+ZvlQJV+VbK+vGj276qEtTmSN3XPZZgF1XbWptvkzIWDszLhHiZmg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/client-sso": "3.281.0",
 				"@aws-sdk/property-provider": "3.272.0",
@@ -6472,6 +6522,7 @@
 			"integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/property-provider": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -6484,6 +6535,7 @@
 			"integrity": "sha512-xp0e49jlSHCH/jt+G89PF1L2MbiGnSSwCxehyEBcIzX5xfdPWY8baAgRIT6wGYyNy5mnx1Z32SyfwcG3ns4n9A==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/client-cognito-identity": "3.281.0",
 				"@aws-sdk/client-sso": "3.281.0",
@@ -6508,6 +6560,7 @@
 			"integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/protocol-http": "3.272.0",
 				"@aws-sdk/querystring-builder": "3.272.0",
@@ -6522,6 +6575,7 @@
 			"integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.272.0",
 				"@aws-sdk/util-buffer-from": "3.208.0",
@@ -6535,6 +6589,7 @@
 			"integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -6546,6 +6601,7 @@
 			"integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -6556,6 +6612,7 @@
 			"integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/protocol-http": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -6568,6 +6625,7 @@
 			"integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/middleware-serde": "3.272.0",
 				"@aws-sdk/protocol-http": "3.272.0",
@@ -6585,6 +6643,7 @@
 			"integrity": "sha512-oTkF3exy89KE8NgSeXFwD+0H0GRKL2qUw92t3caEj7+4KzU/0m3t7NtKlq2NLRtTJhZ/izYRpV536oogLzGm3g==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/protocol-http": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -6597,6 +6656,7 @@
 			"integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -6608,6 +6668,7 @@
 			"integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/protocol-http": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -6620,6 +6681,7 @@
 			"integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/protocol-http": "3.272.0",
 				"@aws-sdk/service-error-classification": "3.272.0",
@@ -6635,7 +6697,8 @@
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				}
 			}
 		},
@@ -6645,6 +6708,7 @@
 			"integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/middleware-signing": "3.272.0",
 				"@aws-sdk/property-provider": "3.272.0",
@@ -6660,6 +6724,7 @@
 			"integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -6671,6 +6736,7 @@
 			"integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/property-provider": "3.272.0",
 				"@aws-sdk/protocol-http": "3.272.0",
@@ -6686,6 +6752,7 @@
 			"integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -6696,6 +6763,7 @@
 			"integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/protocol-http": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -6708,6 +6776,7 @@
 			"integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/property-provider": "3.272.0",
 				"@aws-sdk/shared-ini-file-loader": "3.272.0",
@@ -6721,6 +6790,7 @@
 			"integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/abort-controller": "3.272.0",
 				"@aws-sdk/protocol-http": "3.272.0",
@@ -6735,6 +6805,7 @@
 			"integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -6746,6 +6817,7 @@
 			"integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -6757,6 +6829,7 @@
 			"integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.272.0",
 				"@aws-sdk/util-uri-escape": "3.201.0",
@@ -6769,6 +6842,7 @@
 			"integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -6779,7 +6853,8 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
 			"integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"@aws-sdk/shared-ini-file-loader": {
 			"version": "3.272.0",
@@ -6787,6 +6862,7 @@
 			"integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -6798,6 +6874,7 @@
 			"integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/is-array-buffer": "3.201.0",
 				"@aws-sdk/types": "3.272.0",
@@ -6814,6 +6891,7 @@
 			"integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/middleware-stack": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -6826,6 +6904,7 @@
 			"integrity": "sha512-36Vg/F6Edm7qdjcTeNVON+sK2edgHhmhTtAEjWcuUk5AX/Et+Ate/A2N8HD3nxwlAcgidfnBC9SHYJatbhcEnQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/client-sso-oidc": "3.281.0",
 				"@aws-sdk/property-provider": "3.272.0",
@@ -6840,6 +6919,7 @@
 			"integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -6850,6 +6930,7 @@
 			"integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/querystring-parser": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -6862,6 +6943,7 @@
 			"integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/util-buffer-from": "3.208.0",
 				"tslib": "^2.3.1"
@@ -6873,6 +6955,7 @@
 			"integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -6883,6 +6966,7 @@
 			"integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -6893,6 +6977,7 @@
 			"integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/is-array-buffer": "3.201.0",
 				"tslib": "^2.3.1"
@@ -6904,6 +6989,7 @@
 			"integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -6914,6 +7000,7 @@
 			"integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/property-provider": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -6927,6 +7014,7 @@
 			"integrity": "sha512-A2NB10xReWC+GSnOivKGZ9rnljIZdEP8WMCQQEnA6DJNI19AUFF/O9QJ9y+cHGLKEms7jH86Y99wShdpzAK+Jw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/config-resolver": "3.272.0",
 				"@aws-sdk/credential-provider-imds": "3.272.0",
@@ -6942,6 +7030,7 @@
 			"integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.272.0",
 				"tslib": "^2.3.1"
@@ -6953,6 +7042,7 @@
 			"integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -6963,6 +7053,7 @@
 			"integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -6973,6 +7064,7 @@
 			"integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -6983,6 +7075,7 @@
 			"integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/service-error-classification": "3.272.0",
 				"tslib": "^2.3.1"
@@ -6994,6 +7087,7 @@
 			"integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -7004,6 +7098,7 @@
 			"integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.272.0",
 				"bowser": "^2.11.0",
@@ -7016,6 +7111,7 @@
 			"integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/node-config-provider": "3.272.0",
 				"@aws-sdk/types": "3.272.0",
@@ -7028,6 +7124,7 @@
 			"integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/util-buffer-from": "3.208.0",
 				"tslib": "^2.3.1"
@@ -7039,6 +7136,7 @@
 			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -7260,6 +7358,16 @@
 			"requires": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
+			}
+		},
+		"@mongodb-js/saslprep": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+			"integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"sparse-bitfield": "^3.0.3"
 			}
 		},
 		"@sinonjs/commons": {
@@ -7543,12 +7651,6 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
-		"base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true
-		},
 		"bluebird": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
@@ -7559,7 +7661,8 @@
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
 			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -7578,23 +7681,10 @@
 			"dev": true
 		},
 		"bson": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
-			"integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.6.0"
-			}
-		},
-		"buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"requires": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-5.5.0.tgz",
+			"integrity": "sha512-B+QB4YmDx9RStKv8LLSl/aVIEV3nYJc3cJNNTK2Cd1TL+7P+cNpw9mAPeCgc5K+j01Dv6sxUzcITXDx7ZU3F0w==",
+			"dev": true
 		},
 		"buffer-from": {
 			"version": "1.1.2",
@@ -8268,6 +8358,7 @@
 			"integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"strnum": "^1.0.5"
 			}
@@ -8588,12 +8679,6 @@
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
-		},
-		"ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true
 		},
 		"ignore": {
 			"version": "3.3.10",
@@ -9265,15 +9350,14 @@
 			}
 		},
 		"mongodb": {
-			"version": "4.14.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.14.0.tgz",
-			"integrity": "sha512-coGKkWXIBczZPr284tYKFLg+KbGPPLlSbdgfKAb6QqCFt5bo5VFZ50O3FFzsw4rnkqjwT6D8Qcoo9nshYKM7Mg==",
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.0.tgz",
+			"integrity": "sha512-g+GCMHN1CoRUA+wb1Agv0TI4YTSiWr42B5ulkiAfLLHitGK1R+PkSAf3Lr5rPZwi/3F04LiaZEW0Kxro9Fi2TA==",
 			"dev": true,
 			"requires": {
-				"@aws-sdk/credential-providers": "^3.186.0",
-				"bson": "^4.7.0",
-				"mongodb-connection-string-url": "^2.5.4",
-				"saslprep": "^1.0.3",
+				"@mongodb-js/saslprep": "^1.1.0",
+				"bson": "^5.5.0",
+				"mongodb-connection-string-url": "^2.6.0",
 				"socks": "^2.7.1"
 			}
 		},
@@ -9943,16 +10027,6 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
-		"saslprep": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"sparse-bitfield": "^3.0.3"
-			}
-		},
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -10250,7 +10324,8 @@
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
 			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"supports-color": {
 			"version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"eslint-config-airbnb-base": "13.1.0",
 		"eslint-plugin-import": "2.17.2",
 		"mocha": "6.1.4",
-		"mongodb": "^4.14.0",
+		"mongodb": "^5.9.0",
 		"nyc": "14.1.1",
 		"prettier": "1.17.0",
 		"should": "13.2.3",
@@ -46,7 +46,7 @@
 		"typescript": "^4.9.5"
 	},
 	"peerDependencies": {
-		"mongodb": "^4.14.0"
+		"mongodb": "^4.14.0 || ^5.9.0"
 	},
 	"engines": {
 		"node": ">=8"

--- a/src/lib/Queue.ts
+++ b/src/lib/Queue.ts
@@ -474,11 +474,7 @@ export default class Queue extends EventEmitter {
   }
 
   private async doesCollectionExist(name) {
-    return new Promise((resolve, reject) => {
-      return this.client.db().listCollections({ name }).toArray((error, items = []) => {
-        if (error) reject(error)
-        resolve(items.length > 0)
-      });
-    });
+    const collections = await this.client.db().listCollections({ name }).toArray();
+    return collections.length > 0;
   }
 }


### PR DESCRIPTION
* Mongodb 5.x removed the callback option, hence we need to update the portion of code using callbacks to use async instead.
** Keeping 4.x in the peer dep as the change is backwards compatible.

Reviewed the rest of breaking changes and not seeing anything else that apply